### PR TITLE
Allow setting language from query param, typo fixes, and wasm phrases

### DIFF
--- a/examples/introduction/introduction.all.en-us.md
+++ b/examples/introduction/introduction.all.en-us.md
@@ -3,7 +3,7 @@
 Let's do a brief introduction into major concepts of WebAssembly:
 
 - WebAssembly is a compile-targeted language for running bytecode on the web.
-- Relative to Javascript, WebAssembly offers predictable performance. It is not inherently **faster** than Javascript, but it **can be faster in JavaScript** in the correct use case. Such as **computationally instensive tasks**, like nested loops or handling large amounts of data. Therefore, **WebAssembly is a compliment to JavaScript, and not a replacement**.
+- Relative to Javascript, WebAssembly offers predictable performance. It is not inherently **faster** than Javascript, but it **can be faster than JavaScript** in the correct use case. Such as **computationally instensive tasks**, like nested loops or handling large amounts of data. Therefore, **WebAssembly is a compliment to JavaScript, and not a replacement**.
 - WebAssembly runs on: all major web browsers, V8 runtimes like [Node.js](https://nodejs.org/en/), and independent Wasm runtimes like [Wasmer](https://github.com/wasmerio/wasmer).
 - WebAssembly has Linear Memory, in other words, one big expandable array. And in the context of Javascript, synchronously accesible by Javascript and Wasm.
 - WebAssembly can export functions and constants, And in the context of Javascript, synchronously accesible by Javascript and Wasm.

--- a/shell/about.html
+++ b/shell/about.html
@@ -16,12 +16,12 @@
 
     <p>
       Wasm By Example is a concise, hands-on introduction to WebAssembly using
-      code snippets and annotated example programs. If you "learn best by
-      doing", or just need a good starting point for a concept, this is the
-      place for you. Wasm By Example offers examples in multiple programming /
-      written languages, where the languages are available for the example.
-      Browse the list of examples below. If you can't find what you are looking
-      for, feel free to
+      code snippets and annotated WebAssembly example programs. If you "learn
+      best by doing", or just need a good starting point for a concept, this is
+      the place for you. Wasm By Example offers wasm examples in multiple
+      programming / written languages, where the languages are available for the
+      example. Browse the list of wasm examples below. If you can't find what
+      you are looking for, feel free to
       <a
         target="_blank"
         rel="noopener"

--- a/shell/all-examples-list.html
+++ b/shell/all-examples-list.html
@@ -18,10 +18,11 @@
 
     <div>
       <p>
-        Below is a list of all available examples on Wasm by Example. Organized
-        by their respective language. Currently, this
+        Below is a list of all available WebAssembly examples on Wasm by
+        Example. Organized by their respective language. Currently, this
         <b>will not switch your language preferences</b>. But will allow you to
-        see another example without having to set the default language.
+        see another WebAssembly example without having to set the default
+        language.
       </p>
     </div>
 

--- a/shell/index.html
+++ b/shell/index.html
@@ -24,7 +24,7 @@
       Wasm offer a compact binary format, with predictable performance to run
       alongside Javascript. Wasm is currently shipped in all major browsers, and
       has runtimes meant for running on servers or interfacing with systems
-      using WASI. To get started, browse the list of examples below.
+      using WASI. To get started, browse the list of WebAssembly examples below.
     </p>
 
     <!-- List of examples -->

--- a/shell/js/index.js
+++ b/shell/js/index.js
@@ -20,6 +20,9 @@ window.WASM_BY_EXAMPLE = {
   readingLanguage: "en-us"
 };
 
+// Define some constants
+const languageSelectKeys = ["programmingLanguage", "readingLanguage"];
+
 // Define some utility functions
 const createOptionElement = (text, value) => {
   const optionElement = document.createElement("option");
@@ -29,8 +32,6 @@ const createOptionElement = (text, value) => {
 };
 
 const setLanguagePreferenceFromForm = () => {
-  const languageSelectKeys = ["programmingLanguage", "readingLanguage"];
-
   languageSelectKeys.forEach(key => {
     const select = document.querySelector(`select#${key}`);
     if (select && select.value) {
@@ -47,6 +48,21 @@ const submitSettingsForm = () => {
 
 // Initialization IIFE
 (() => {
+  // Handle URL Params if we have them
+  let params = new URLSearchParams(window.location.search);
+  languageSelectKeys.forEach(key => {
+    if (params.has(key)) {
+      const paramValue = params.get(key);
+      const availableValues =
+        key === "programmingLanguage"
+          ? Object.values(window.WASM_BY_EXAMPLE_PROGRAMMING_LANGUAGES)
+          : Object.values(window.WASM_BY_EXAMPLE_READING_LANGUAGES);
+      if (availableValues.includes(paramValue)) {
+        localStorage.setItem(key, paramValue);
+      }
+    }
+  });
+
   // Set our correct global settings
   Object.keys(window.WASM_BY_EXAMPLE).forEach(key => {
     const savedItem = localStorage.getItem(key);

--- a/shell/partials/head.html
+++ b/shell/partials/head.html
@@ -4,5 +4,5 @@
 <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 <meta
   name="description"
-  content="A hands-on introduction into WebAssembly ( Wasm ). Containing simple examples and tutorials on how to implement concepts and various tasks using Wasm."
+  content="A hands-on introduction into WebAssembly ( Wasm ). Containing simple wasm examples and wasm tutorials on how to implement concepts and various tasks using WebAssembly."
 />


### PR DESCRIPTION
closes #36 
closes #40 
closes #39 

As the title states, see the issues for more info :smile: But the following now works:

![Screenshot from 2019-07-25 01-10-42](https://user-images.githubusercontent.com/1448289/61857458-11895700-ae79-11e9-8947-d32ce4520b67.png)
