### PR TITLE
Fix title mobile

### DIFF
--- a/shell/partials/header.html
+++ b/shell/partials/header.html
@@ -1,5 +1,13 @@
 <div class="flex-column">
-  <h1><a href="/" class="title">Wasm By Example</a></h1>
+  <a href="/" class="flex-row title">
+    <img
+      src="Web_Assembly_Logo.svg"
+      width="65px"
+      height="65px"
+      alt="WebAssembly Logo"
+    />
+    <h1>Wasm By Example</h1>
+  </a>
   <div class="language-picker flex-row">
     <div class="language-title">Language:</div>
     <form>

--- a/shell/styles/index.css
+++ b/shell/styles/index.css
@@ -31,6 +31,10 @@ a:hover {
   text-decoration: none;
 }
 
+.title h1 {
+  font-size: 1.8em;
+}
+
 .language-title {
   font-size: 1.35em;
 }


### PR DESCRIPTION
After add the logo image, the current font-size of title was making it wrap in two lines in mobile devices, so I reduced the title font-size to display title in one line in mobile.

![image](https://user-images.githubusercontent.com/4308648/62824835-2c461600-bb71-11e9-8f1e-cc2869e3bc16.png)
