### PR TITLE
Fixed the header src on example pages, as well as underline on header hover

### DIFF
--- a/shell/partials/header.html
+++ b/shell/partials/header.html
@@ -1,7 +1,7 @@
 <div class="flex-column">
   <a href="/" class="flex-row title">
     <img
-      src="Web_Assembly_Logo.svg"
+      src="/Web_Assembly_Logo.svg"
       width="65px"
       height="65px"
       alt="WebAssembly Logo"

--- a/shell/styles/index.css
+++ b/shell/styles/index.css
@@ -94,6 +94,11 @@ a:hover {
   border-bottom: 0px;
 }
 
+.title:hover {
+  text-decoration: none;
+  border-bottom: 0px;
+}
+
 .title h1 {
   font-size: 1.8em;
 }


### PR DESCRIPTION
As the title states!

# Example

Hovering over header, and logo being shown on example path

![Screenshot from 2019-08-13 01-27-38](https://user-images.githubusercontent.com/1448289/62926532-8b6e7b00-bd69-11e9-9b85-6771cc76b4a7.png)
