### PR TITLE
Preload key requests

### DIFF
--- a/examples/hello-world/demo/assemblyscript/index.html
+++ b/examples/hello-world/demo/assemblyscript/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Hello World - AssemblyScript</title>
+    <link rel="preload" href="./hello-world.js" as="script" />
   </head>
   <body>
     <script type="module" src="./hello-world.js"></script>

--- a/examples/hello-world/demo/rust/index.html
+++ b/examples/hello-world/demo/rust/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Hello World - Rust</title>
+    <link rel="preload" href="./index.js" as="script" />
   </head>
   <body>
     <script type="module" src="./index.js"></script>

--- a/examples/importing-javascript-functions-into-webassembly/demo/assemblyscript/index.html
+++ b/examples/importing-javascript-functions-into-webassembly/demo/assemblyscript/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Importing Javascript Functions into Wasm - AssemblyScript</title>
+    <link rel="preload" href="./index.js" as="script" />
     <script type="module" src="./index.js"></script>
   </head>
   <body></body>

--- a/examples/importing-javascript-functions-into-webassembly/demo/rust/index.html
+++ b/examples/importing-javascript-functions-into-webassembly/demo/rust/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Hello World - Rust</title>
+    <link rel="preload" href="./index.js" as="script" />
   </head>
   <body>
     <script type="module" src="./index.js"></script>

--- a/examples/reading-and-writing-audio/demo/assemblyscript/index.html
+++ b/examples/reading-and-writing-audio/demo/assemblyscript/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Audio - AssemblyScript</title>
+    <link rel="preload" href="./index.js" as="script" />
     <script type="module" src="./index.js"></script>
   </head>
   <body>

--- a/examples/reading-and-writing-audio/demo/rust/index.html
+++ b/examples/reading-and-writing-audio/demo/rust/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Reading and Writing Audio - Rust</title>
+    <link rel="preload" href="./index.js" as="script" />
     <script type="module" src="./index.js"></script>
   </head>
   <body>

--- a/examples/reading-and-writing-graphics/demo/rust/index.html
+++ b/examples/reading-and-writing-graphics/demo/rust/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Graphics - Rust</title>
+    <link rel="preload" href="./index.js" as="script" />
     <script type="module" src="./index.js"></script>
   </head>
   <body>

--- a/examples/strings/demo/rust/index.html
+++ b/examples/strings/demo/rust/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Strings - Rust</title>
+    <link rel="preload" href="./index.js" as="script" />
   </head>
   <body>
     <script type="module" src="./index.js"></script>

--- a/examples/webassembly-linear-memory/demo/assemblyscript/index.html
+++ b/examples/webassembly-linear-memory/demo/assemblyscript/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>WebAssembly Linear Memory - AssemblyScript</title>
+    <link rel="preload" href="./index.js" as="script" />
     <script type="module" src="./index.js"></script>
   </head>
   <body></body>

--- a/examples/webassembly-linear-memory/demo/rust/index.html
+++ b/examples/webassembly-linear-memory/demo/rust/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Hello World - Rust</title>
+    <link rel="preload" href="./index.js" as="script" />
   </head>
   <body>
     <script type="module" src="./index.js"></script>


### PR DESCRIPTION
Let's make 100 in PageSpeed Insights.

Consider using `<link rel=preload>` to prioritize fetching resources that are currently requested later in page load. 

![image](https://user-images.githubusercontent.com/4308648/65334437-681cc400-db90-11e9-8aa4-5d9d48c3d864.png)
