### PR TITLE
changed use line import init instead of wasmInit and changed file name

### DIFF
--- a/examples/hello-world/hello-world.rust.en-us.md
+++ b/examples/hello-world/hello-world.rust.en-us.md
@@ -75,7 +75,7 @@ This will output a `pkg/` directory containing our wasm module, wrapped in a js 
 ```javascript
 // Import our outputted wasm ES6 module
 // Which, export default's, an initialization function
-import wasmInit from "./pkg/exports.js";
+import init from "./pkg/hello_world.js";
 
 const runWasm = async () => {
   // Instantiate our wasm module


### PR DESCRIPTION
I think that this should be `init` and `hello_world.js`, based on the current output of wasm-pack.  I filed an issue to the effect also; sorry for the replication.