### PR TITLE
Fix import to align with the later used function

### DIFF
--- a/examples/hello-world/hello-world.rust.en-us.md
+++ b/examples/hello-world/hello-world.rust.en-us.md
@@ -75,7 +75,7 @@ This will output a `pkg/` directory containing our wasm module, wrapped in a js 
 ```javascript
 // Import our outputted wasm ES6 module
 // Which, export default's, an initialization function
-import init from "./pkg/hello_world.js";
+import wasmInit from "./pkg/hello_world.js";
 
 const runWasm = async () => {
   // Instantiate our wasm module


### PR DESCRIPTION
Instead of init, wasmInit should be imported.
Init is never used, but wasmInit is:

```
  const helloWorld = await wasmInit("./pkg/hello_world_bg.wasm");
```

I've changed the import to wasmInit, since that's what's imported in the
examples for the other languages as well.