### PR TITLE
Replace use of wasmInit with init in Rust Hello World

### DIFF
--- a/examples/hello-world/hello-world.rust.en-us.md
+++ b/examples/hello-world/hello-world.rust.en-us.md
@@ -79,7 +79,7 @@ import init from "./pkg/hello_world.js";
 
 const runWasm = async () => {
   // Instantiate our wasm module
-  const helloWorld = await wasmInit("./pkg/hello_world_bg.wasm");
+  const helloWorld = await init("./pkg/hello_world_bg.wasm");
 
   // Call the Add function export from wasm, save the result
   const addResult = helloWorld.add(24, 24);


### PR DESCRIPTION
Instead of using wasmInit, the function should use init, as this is the
init that's actually generated.

Unfortunately this doesn't align with the other languages which all use
wasmInit.