### PR TITLE
Hide the .pt-br translation

### DIFF
--- a/shell/js/index.js
+++ b/shell/js/index.js
@@ -17,7 +17,8 @@ window.WASM_BY_EXAMPLE_PROGRAMMING_LANGUAGES["TinyGo (Go)"] = "go";
 // Define Global Reading Languages
 window.WASM_BY_EXAMPLE_READING_LANGUAGES = {};
 window.WASM_BY_EXAMPLE_READING_LANGUAGES["English (US)"] = "en-us";
-window.WASM_BY_EXAMPLE_READING_LANGUAGES["Brazilian Portuguese"] = "pt-br";
+// TODO: Re-add this translation once links to other translations are fixed (#94)
+// window.WASM_BY_EXAMPLE_READING_LANGUAGES["Brazilian Portuguese"] = "pt-br";
 
 // Define Default Settings
 window.WASM_BY_EXAMPLE = {


### PR DESCRIPTION
Per https://github.com/torch2424/wasm-by-example/pull/94#issuecomment-650609695

This hides the .pt-br translation until links are fixed for other translations :smile: :+1: 

# Screenshot

![Screenshot from 2020-06-28 21-55-08](https://user-images.githubusercontent.com/1448289/85974438-499ef100-b98a-11ea-95e7-c5db99590e7b.png)
