### PR TITLE
Improved Service Worker Caching / Added Made With WebAssembly

### DIFF
--- a/build-system/build.js
+++ b/build-system/build.js
@@ -318,12 +318,19 @@ const buildTask = async () => {
   await cpy(["shell/manifest.json"], "dist/");
 
   // Generate our Service Worker
+  // TODO: Once bug is fixed, set cache strategy on precache
+  // https://github.com/GoogleChrome/workbox/issues/1767
+  const getEpoch = () => Date.now();
+  const cacheId = `wasm-by-example%%${getEpoch()}%%`;
   const workboxResponse = await workboxBuild.generateSW({
+    cacheId: cacheId,
     globDirectory: "dist",
-    globPatterns: ["**/*.{html,json,js,css,svg,jpg,wasm}"],
+    globPatterns: ["**/*.{html,json,js,css,svg,jpg,png,wasm}"],
     swDest: "dist/service-worker.js",
-    ignoreURLParametersMatching: [/.*exampleName.*/, /.*example-name.*/]
+    ignoreURLParametersMatching: [/.*exampleName.*/, /.*example-name.*/],
+    skipWaiting: true
   });
+  console.log("Cache Id: ", cacheId);
   console.log("WorkBox Response: \n", workboxResponse, "\n");
 
   console.log("Done!");

--- a/examples/hello-world/hello-world.assemblyscript.en-us.md
+++ b/examples/hello-world/hello-world.assemblyscript.en-us.md
@@ -6,7 +6,7 @@
 
 For our first program, we will be doing a "Hello world" type of program in [AssemblyScript](https://github.com/AssemblyScript/assemblyscript). AssemblyScript, is essentially a TypeScript to WebAssembly compiler. This is great for TypeScript and JavaScript developers who want to write WebAssembly, without learning a new language. Though, to be clear, you can not compile our TypeScript React apps to WebAssembly with AssemblyScript because of its differences from TypeScript. But is still a great language for building WebAssembly applications.
 
-To keep things simple with Wasm's limitations mentioned [in the introduction example](/example-redirect?exampleName=introduction&programmingLanguage=all), instead of displaying a string, we will add two numbers together and display the result. Though, it is good to keep in mind, in later examples, a lot of these limitations will be abstracted away by your WebAssembly Language of choice (In this case, AssemblyScript).
+To keep things simple with Wasm's limitations mentioned [in the introduction example](/example-redirect?exampleName=introduction&programmingLanguage=all), instead of displaying a string, we will add two numbers together and display the result. Though, it is good to keep in mind, in later examples, a lot of these limitations will be abstracted away by your WebAssembly Language of choice (In this case, AssemblyScript)
 
 ---
 

--- a/examples/hello-world/hello-world.assemblyscript.en-us.md
+++ b/examples/hello-world/hello-world.assemblyscript.en-us.md
@@ -6,7 +6,7 @@
 
 For our first program, we will be doing a "Hello world" type of program in [AssemblyScript](https://github.com/AssemblyScript/assemblyscript). AssemblyScript, is essentially a TypeScript to WebAssembly compiler. This is great for TypeScript and JavaScript developers who want to write WebAssembly, without learning a new language. Though, to be clear, you can not compile our TypeScript React apps to WebAssembly with AssemblyScript because of its differences from TypeScript. But is still a great language for building WebAssembly applications.
 
-To keep things simple with Wasm's limitations mentioned [in the introduction example](/example-redirect?exampleName=introduction&programmingLanguage=all), instead of displaying a string, we will add two numbers together and display the result. Though, it is good to keep in mind, in later examples, a lot of these limitations will be abstracted away by your WebAssembly Language of choice (In this case, AssemblyScript)
+To keep things simple with Wasm's limitations mentioned [in the introduction example](/example-redirect?exampleName=introduction&programmingLanguage=all), instead of displaying a string, we will add two numbers together and display the result. Though, it is good to keep in mind, in later examples, a lot of these limitations will be abstracted away by your WebAssembly Language of choice (In this case, AssemblyScript).
 
 ---
 

--- a/shell/additional-resources.html
+++ b/shell/additional-resources.html
@@ -56,6 +56,15 @@
         <a
           target="_blank"
           rel="noopener"
+          href="https://madewithwebassembly.com/"
+        >
+          Made With WebAssembly
+        </a>
+      </li>
+      <li>
+        <a
+          target="_blank"
+          rel="noopener"
           href="https://github.com/mbasso/awesome-wasm"
         >
           awesome-wasm

--- a/shell/partials/head.html
+++ b/shell/partials/head.html
@@ -19,6 +19,40 @@
     window.addEventListener("load", () => {
       navigator.serviceWorker.register("/service-worker.js");
     });
+
+    // Workbox doesn't allow choosing NetworkFirst for caches
+    // https://github.com/GoogleChrome/workbox/issues/1767
+    // Thus, what we are going to do is create new caches every deploy
+    // And just delete old caches
+    // Delete old service worker caches
+    caches.keys().then(cacheNames => {
+      // Check if the cache name includes %%
+      cacheNames.forEach(cacheName => {
+        if (!cacheName.includes("wasm-by-example%%")) {
+          caches.delete(cacheName);
+        }
+      });
+
+      // Sort our caches
+      cacheNames.sort((a, b) => {
+        // Get the epochs in the cache names
+        aEpoch = parseInt(a.split("%%")[1], 10);
+        bEpoch = parseInt(b.split("%%")[1], 10);
+
+        if (aEpoch < bEpoch) {
+          return 1;
+        } else if (aEpoch > bEpoch) {
+          return -1;
+        }
+
+        return 0;
+      });
+
+      // Delete the old caches
+      cacheNames.slice(1).forEach(oldCacheName => {
+        caches.delete(oldCacheName);
+      });
+    });
   }
 </script>
 <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
closes #93 

So As #93 hinted, it seemed like the default strategy for precaching was CacheFirst :upside_down_face: :cry: Which is not good, meaning people were not able to see any updates, as we were precaching essentially everything, therefore nothing would be updated.

And changing the strategy to NetworkFirst in our `generateSW` is not possible, as outlined in: https://github.com/GoogleChrome/workbox/issues/1767

Thus, what this does, is assign a new cache id on every build that gets deployed. Therefore, whenever a new build goes out and the user visits the site, the new service worker will install, and re-precache the entire site again. After this is done, it will then [delete the old cache](https://gist.github.com/deanhume/4b7e1f136cbee288cff9f0fc46318fbb) as it is no longer needed! Caches are denoted by the epoch in their ID. That way we kinda get a best of both worlds scenario, though, NetworkFirst would still be preferred, once it's available :smile: 

Also, this adds Made with WebAssembly to the additional resources

![Screenshot from 2020-07-27 15-35-12](https://user-images.githubusercontent.com/1448289/88598782-e2bf3700-d01e-11ea-991b-f72566416ff2.png)

