### PR TITLE
typo at line 62 in wasi-hello-world.rust.en-us.md

### DIFF
--- a/examples/wasi-hello-world/wasi-hello-world.rust.en-us.md
+++ b/examples/wasi-hello-world/wasi-hello-world.rust.en-us.md
@@ -58,7 +58,7 @@ Our wasm file should be compiled to `target/wasm32-wasi/debug/wasi_hello_world.w
 
 To do this, we can use the Wasmtime CLI, which we mentioned should be installed at the beginning of this tutorial. However, there is one thing to note that was mentioned in the code comments. **We need to give our program explicit access to create files on our host, because our program creates a new file**. As mentioned in the [WASI Introduction](/example-redirect?exampleName=wasi-introduction), our guest will not have this capability unless we give them the capability.
 
-To grant the capability to write in a directory using the Wasmtime CLI, we need to use the `--mapdir` flag. `--mapdir` will allow us to map the `/helloworld` directory on the guest's virual filesystem, to the current directory (`.`) on the host fileystem. For example:
+To grant the capability to write in a directory using the Wasmtime CLI, we need to use the `--mapdir` flag. `--mapdir` will allow us to map the `/helloworld` directory on the guest's virtual filesystem, to the current directory (`.`) on the host fileystem. For example:
 
 ```bash
 wasmtime --mapdir GUEST_DIRECTORY::HOST_DIRECTORY my-wasi-program.wasm


### PR DESCRIPTION
simply fixed a typo 
before - "virual filesystem"
after - ""virtual filesystem""