### PR TITLE
Fixed image-rendering in graphics examples for firefox in example html

### DIFF
--- a/examples/reading-and-writing-graphics/reading-and-writing-graphics.assemblyscript.en-us.md
+++ b/examples/reading-and-writing-graphics/reading-and-writing-graphics.assemblyscript.en-us.md
@@ -180,7 +180,7 @@ Lastly, lets load our ES6 Module, `index.js` Javascript file in our `index.html`
   <canvas
     width="20"
     height="20"
-    style="image-rendering: pixelated; width: 100%;"
+    style="image-rendering: pixelated; image-rendering: crisp-edges; width: 100%;"
   >
   </canvas>
 </body>

--- a/examples/reading-and-writing-graphics/reading-and-writing-graphics.rust.en-us.md
+++ b/examples/reading-and-writing-graphics/reading-and-writing-graphics.rust.en-us.md
@@ -197,7 +197,7 @@ Lastly, lets load our ES6 Module, `index.js` Javascript file in our `index.html`
   <canvas
     width="20"
     height="20"
-    style="image-rendering: pixelated; width: 100%;"
+    style="image-rendering: pixelated; image-rendering: crisp-edges; width: 100%;"
   >
   </canvas>
 </body>

--- a/examples/reading-and-writing-graphics/reading-and-writing-graphics.rust.pt-br.md
+++ b/examples/reading-and-writing-graphics/reading-and-writing-graphics.rust.pt-br.md
@@ -195,7 +195,7 @@ Por último, carregamos o nosso Módulo ES6, o arquivo Javascript `index.js`, no
   <canvas
     width="20"
     height="20"
-    style="image-rendering: pixelated; width: 100%;"
+    style="image-rendering: pixelated; image-rendering: crisp-edges; width: 100%;"
   >
   </canvas>
 </body>


### PR DESCRIPTION
closes #116 :smile: :tada: 

![Screenshot from 2021-02-09 11-22-54](https://user-images.githubusercontent.com/1448289/107416318-31b75000-6ac9-11eb-973c-9f067863648a.png)
