### PR TITLE
Change value to 15 to be consistent with the rest of the example

### DIFF
--- a/examples/webassembly-linear-memory/demo/assemblyscript/index.js
+++ b/examples/webassembly-linear-memory/demo/assemblyscript/index.js
@@ -23,9 +23,9 @@ const runWasmAdd = async () => {
 
   // Next let's write to index one, to make sure we can
   // write wasm memory, and Wasm can read the "passed" value from JS
-  wasmByteMemoryArray[1] = 25;
+  wasmByteMemoryArray[1] = 15;
   domConsoleLog(
     "Read from Wasm index one: " + exports.readWasmMemoryAndReturnIndexOne()
-  ); // Should Log "25"
+  ); // Should Log "15"
 };
 runWasmAdd();

--- a/examples/webassembly-linear-memory/demo/go/index.js
+++ b/examples/webassembly-linear-memory/demo/go/index.js
@@ -38,13 +38,13 @@ const runWasm = async () => {
   domConsoleLog("Write in JS, Read in Wasm, Index 1:");
 
   // First, let's write to index one of our buffer
-  wasmMemory[bufferPointer + 1] = 25;
+  wasmMemory[bufferPointer + 1] = 15;
 
   // Then, let's have wasm read index one of the buffer,
   // and return the result
   domConsoleLog(
     wasmModule.instance.exports.readWasmMemoryBufferAndReturnIndexOne()
-  ); // Should log "25"
+  ); // Should log "15"
 
   /**
    * NOTE: if we were to continue reading and writing memory,

--- a/examples/webassembly-linear-memory/demo/rust/index.js
+++ b/examples/webassembly-linear-memory/demo/rust/index.js
@@ -30,11 +30,11 @@ const runWasm = async () => {
   domConsoleLog("Write in JS, Read in Wasm, Index 1:");
 
   // First, let's write to index one of our buffer
-  wasmMemory[bufferPointer + 1] = 25;
+  wasmMemory[bufferPointer + 1] = 15;
 
   // Then, let's have wasm read index one of the buffer,
   // and return the result
-  domConsoleLog(rustWasm.read_wasm_memory_buffer_and_return_index_one()); // Should log "25"
+  domConsoleLog(rustWasm.read_wasm_memory_buffer_and_return_index_one()); // Should log "15"
 
   /**
    * NOTE: if we were to continue reading and writing memory,

--- a/examples/webassembly-linear-memory/webassembly-linear-memory.assemblyscript.en-us.md
+++ b/examples/webassembly-linear-memory/webassembly-linear-memory.assemblyscript.en-us.md
@@ -68,8 +68,8 @@ const runWasm = async () => {
 
   // Next let's write to index one, to make sure we can
   // write wasm memory, and Wasm can read the "passed" value from JS
-  wasmByteMemoryArray[1] = 25;
-  console.log(exports.readWasmMemoryAndReturnIndexOne()); // Should Log "25"
+  wasmByteMemoryArray[1] = 15;
+  console.log(exports.readWasmMemoryAndReturnIndexOne()); // Should Log "15"
 };
 runWasm();
 ```

--- a/examples/webassembly-linear-memory/webassembly-linear-memory.go.en-us.md
+++ b/examples/webassembly-linear-memory/webassembly-linear-memory.go.en-us.md
@@ -97,13 +97,13 @@ const runWasm = async () => {
   console.log("Write in JS, Read in Wasm, Index 1:");
 
   // First, let's write to index one of our buffer
-  wasmMemory[bufferPointer + 1] = 25;
+  wasmMemory[bufferPointer + 1] = 15;
 
   // Then, let's have wasm read index one of the buffer,
   // and return the result
   console.log(
     wasmModule.instance.exports.readWasmMemoryBufferAndReturnIndexOne()
-  ); // Should log "25"
+  ); // Should log "15"
 
   /**
    * NOTE: if we were to continue reading and writing memory,

--- a/examples/webassembly-linear-memory/webassembly-linear-memory.rust.pt-br.md
+++ b/examples/webassembly-linear-memory/webassembly-linear-memory.rust.pt-br.md
@@ -74,7 +74,7 @@ const runWasm = async () => {
   /**
    * Part one: Write in Wasm, Read in JS
    */
-  console.log("Write in JS, Read in Wasm, Index 0:");
+  console.log("Write in Wasm, Read in Js, Index 0:");
 
   // First, let's have wasm write to our buffer
   rustWasm.store_value_in_wasm_memory_buffer_index_zero(24);
@@ -95,11 +95,11 @@ const runWasm = async () => {
   console.log("Write in JS, Read in Wasm, Index 1:");
 
   // First, let's write to index one of our buffer
-  wasmMemory[bufferPointer + 1] = 25;
+  wasmMemory[bufferPointer + 1] = 15;
 
   // Then, let's have wasm read index one of the buffer,
   // and return the result
-  console.log(rustWasm.read_wasm_memory_buffer_and_return_index_one()); // Should log "25"
+  console.log(rustWasm.read_wasm_memory_buffer_and_return_index_one()); // Should log "15"
 
   /**
    * NOTE: if we were to continue reading and writing memory,


### PR DESCRIPTION
The PR #121 changed a value in webassembly-linear-memory example, but in the rust.en-us.md file only, which makes an inconsistence between the documentation and the demo.

See https://wasmbyexample.dev/examples/webassembly-linear-memory/webassembly-linear-memory.rust.en-us.html, the documentation says '// Should log "15"' but the demo is showing 25.

My proposal is to add the value "15" to the rest of the example, to be 100% consistent.