### PR TITLE
Add horizontal padding for mobile

### DIFF
--- a/shell/styles/index.css
+++ b/shell/styles/index.css
@@ -14,6 +14,7 @@ body {
 .container {
   max-width: 850px;
   margin: auto;
+  padding: 0px 10px;
 }
 
 .announcements {


### PR DESCRIPTION
I was browsing `wasmbyexample.dev` on my phone when I realized the text inside a `container` class was a little bit hard to read because the lack of horizontal padding. This PR adds that ✅

| Before | After |
|---|---|
| <img width="728" alt="image" src="https://user-images.githubusercontent.com/46694203/187753113-c64e9b40-313a-4140-9cd9-32887fdc85ee.png"> | <img width="724" alt="image" src="https://user-images.githubusercontent.com/46694203/187753229-6bec6242-2f51-49b8-b1ab-92c2b85fc3f6.png"> |