### PR TITLE
fix: Compiler options in AssemblyScript

### DIFF
--- a/examples/hello-world/hello-world.assemblyscript.en-us.md
+++ b/examples/hello-world/hello-world.assemblyscript.en-us.md
@@ -32,7 +32,7 @@ npm install -g assemblyscript
 Now, let's compile that into a wasm module which will output a `hello-world.wasm`:
 
 ```bash
-asc hello-world.ts -b hello-world.wasm
+asc hello-world.ts -o hello-world.wasm
 ```
 
 Next, lets create a `hello-world.js` JavaScript file, and add a function for loading Wasm modules using the [WebAssembly Web APIs](https://developer.mozilla.org/en-US/docs/WebAssembly):


### PR DESCRIPTION
 #157

There is an error in the Compiler option, as described in the implementation, and the wasm file is not generated.
Correct compiler option is `-o` so I fixed it.
> --outFile, -o         Specifies the WebAssembly output file (.wasm).
> https://www.assemblyscript.org/compiler.html#output