### PR TITLE
Add: description of local web server execution in AssemblyScript

### DIFF
--- a/examples/hello-world/hello-world.assemblyscript.en-us.md
+++ b/examples/hello-world/hello-world.assemblyscript.en-us.md
@@ -103,6 +103,8 @@ Lastly, lets load our ES6 Module, `hello-world.js` Javascript file in our `index
 </html>
 ```
 
+You can then run a local webserver (like `python -m http.server 8000`) and browse to `localhost:8000/hello.html`, where you'll see the expected output.
+
 And we should have a working Wasm Add (Hello World) program! Congrats!
 
 You should have something similar to the demo ([Source Code](/source-redirect?path=examples/hello-world/demo/assemblyscript)) below:


### PR DESCRIPTION
The Hello World document in AssemblyScript example does not explain how to start a local server, which I thought was a little unkind, so I added the description.

Based on Emscripten documentation, I have described the Python3 server startup command.
https://wasmbyexample.dev/examples/hello-world/hello-world.c.en-us.html