### PR TITLE
fix: remove unexported import `test` from high level data types example

### DIFF
--- a/examples/passing-high-level-data-types-with-wasm-bindgen/passing-high-level-data-types-with-wasm-bindgen.rust.en-us.md
+++ b/examples/passing-high-level-data-types-with-wasm-bindgen/passing-high-level-data-types-with-wasm-bindgen.rust.en-us.md
@@ -36,10 +36,7 @@ Next, lets create an `index.js` file to load and run our wasm output. Now that w
 // Outputted wasm-bindgen ES Module. As well as importing
 // the named exports that are individual wrapper functions
 // to facilitate handle data passing between JS and Wasm.
-import wasmInit, {
-  add_wasm_by_example_to_string,
-  test
-} from "./pkg/strings.js";
+import wasmInit, { add_wasm_by_example_to_string } from "./pkg/strings.js";
 
 const runWasm = async () => {
   // Instantiate our wasm module

--- a/examples/passing-high-level-data-types-with-wasm-bindgen/passing-high-level-data-types-with-wasm-bindgen.rust.pt-br.md
+++ b/examples/passing-high-level-data-types-with-wasm-bindgen/passing-high-level-data-types-with-wasm-bindgen.rust.pt-br.md
@@ -36,10 +36,7 @@ A seguir, criamos um arquivo `index.js` para carregar e rodar o nosso módulo wa
 // Outputted wasm-bindgen ES Module. As well as importing
 // the named exports that are individual wrapper functions
 // to facilitate handle data passing between JS and Wasm.
-import wasmInit, {
-  add_wasm_by_example_to_string,
-  test
-} from "./pkg/strings.js";
+import wasmInit, { add_wasm_by_example_to_string } from "./pkg/strings.js";
 
 const runWasm = async () => {
   // Instantiate our wasm module


### PR DESCRIPTION
Tutorial Link: https://wasmbyexample.dev/examples/passing-high-level-data-types-with-wasm-bindgen/passing-high-level-data-types-with-wasm-bindgen.rust.en-us.html#

Here in our lib.rs file, we aren't exporting a test function. But we are trying to import in index.js file resulting in an error. This PR fixes that by updating the documentation to remove the unexported import.