### PR TITLE
Commented wasi import, because AssemblyScript no longer requires it

### DIFF
--- a/examples/wasi-hello-world/demo/assemblyscript/assembly/index.ts
+++ b/examples/wasi-hello-world/demo/assemblyscript/assembly/index.ts
@@ -1,6 +1,8 @@
 // As of AssemblyScript 0.10.0, adding `import "wasi"`, will automatically
 // import WASI bindings, and add some nice defaults for compiling to WASI.
-import "wasi";
+// As of AssemblyScript 0.20.0, `import "wasi"` is no longer necessary. Please check
+// you version and either decomment the following line or leave it commented.
+//import "wasi";
 
 // Import Console (for writing to stdout), and FileSystem (for reading/writing files)
 // from "as-wasi". An API for working with WASI in AssemblyScript much easier.

--- a/examples/wasi-hello-world/wasi-hello-world.assemblyscript.en-us.md
+++ b/examples/wasi-hello-world/wasi-hello-world.assemblyscript.en-us.md
@@ -25,7 +25,9 @@ Then, we will open the `assembly/index.ts` and enter the following contents. Ple
 ```typescript
 // As of AssemblyScript 0.10.0, adding `import "wasi"`, will automatically
 // import WASI bindings, and add some nice defaults for compiling to WASI.
-import "wasi";
+// As of AssemblyScript 0.20.0, `import "wasi"` is no longer necessary. Please check
+// you version and either decomment the following line or leave it commented.
+//import "wasi";
 
 // Import Console (for writing to stdout), and FileSystem (for reading/writing files)
 // from "as-wasi". An API for working with WASI in AssemblyScript much easier.


### PR DESCRIPTION
Coming from this StackOverflow [question](https://stackoverflow.com/questions/75362866/server-side-assemblyscript-how-to-read-a-file/75378019#75378019), I suggest at least commenting the import line, because it seems to confuse beginners, and it is also no longer necessary.