### PR TITLE
Fix links to TinyGo website with updated working ones

### DIFF
--- a/examples/exports/demo/go/README.md
+++ b/examples/exports/demo/go/README.md
@@ -1,3 +1,3 @@
 Compile with TinyGo, by running: `tinygo build -o main.wasm -target wasm ./main.go`
 
-`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/webassembly/webassembly/#how-it-works).
+`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/docs/guides/webassembly/wasm/#how-it-works).

--- a/examples/hello-world/demo/go/README.md
+++ b/examples/hello-world/demo/go/README.md
@@ -1,3 +1,3 @@
 Compile with TinyGo, by running: `tinygo build -o main.wasm -target wasm ./main.go`
 
-`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/webassembly/webassembly/#how-it-works).
+`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/docs/guides/webassembly/wasm/#how-it-works).

--- a/examples/hello-world/hello-world.go.en-us.md
+++ b/examples/hello-world/hello-world.go.en-us.md
@@ -61,7 +61,7 @@ Then, let's create an `index.html` that we can use to load our project in the br
 </html>
 ```
 
-In this HTML, we are loading an `index.js` (which we will create in the next step), but before we load that `index.js`, we load a `wasm_exec.js`. **You must add the `wasm_exec.js` to use Go wasm modules in the browser**! To add this file, [You can get the `wasm_exec.js` from your TinyGo root](https://tinygo.org/webassembly/webassembly/#how-it-works). An easy way to do this, as described in [this issue](https://github.com/tinygo-org/tinygo/issues/1070), is to run:
+In this HTML, we are loading an `index.js` (which we will create in the next step), but before we load that `index.js`, we load a `wasm_exec.js`. **You must add the `wasm_exec.js` to use Go wasm modules in the browser**! To add this file, [You can get the `wasm_exec.js` from your TinyGo root](https://tinygo.org/docs/guides/webassembly/wasm/#how-it-works). An easy way to do this, as described in [this issue](https://github.com/tinygo-org/tinygo/issues/1070), is to run:
 
 ```bash
 cp $(tinygo env TINYGOROOT)/targets/wasm_exec.js .
@@ -132,6 +132,6 @@ You should have something similar to the demo ([Source Code](/source-redirect?pa
 
 <iframe title="Go Demo" src="/demo-redirect?example-name=hello-world"></iframe>
 
-Before moving on it would be good to note, another great resource for learning TinyGo Wasm by example is taking a look at the official [TinyGo Wasm examples](https://github.com/tinygo-org/tinygo/tree/master/src/examples/wasm). As well as, the [TinyGo Wasm Documentation](https://tinygo.org/webassembly/webassembly/).
+Before moving on it would be good to note, another great resource for learning TinyGo Wasm by example is taking a look at the official [TinyGo Wasm examples](https://github.com/tinygo-org/tinygo/tree/master/src/examples/wasm). As well as, the [TinyGo Wasm Documentation](https://tinygo.org/docs/guides/webassembly/wasm/).
 
 Next, continuing on with WasmByExample, let's take a deeper look at WebAssembly [Exports](/example-redirect?exampleName=exports).

--- a/examples/importing-javascript-functions-into-webassembly/demo/go/README.md
+++ b/examples/importing-javascript-functions-into-webassembly/demo/go/README.md
@@ -1,3 +1,3 @@
 Compile with TinyGo, by running: `tinygo build -o main.wasm -target wasm ./main.go`
 
-`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/webassembly/webassembly/#how-it-works).
+`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/docs/guides/webassembly/wasm/#how-it-works).

--- a/examples/reading-and-writing-audio/demo/go/README.md
+++ b/examples/reading-and-writing-audio/demo/go/README.md
@@ -1,3 +1,3 @@
 Compile with TinyGo, by running: `tinygo build -o main.wasm -target wasm ./main.go`
 
-`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/webassembly/webassembly/#how-it-works).
+`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/docs/guides/webassembly/wasm/#how-it-works).

--- a/examples/reading-and-writing-graphics/demo/go/README.md
+++ b/examples/reading-and-writing-graphics/demo/go/README.md
@@ -1,3 +1,3 @@
 Compile with TinyGo, by running: `tinygo build -o main.wasm -target wasm ./main.go`
 
-`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/webassembly/webassembly/#how-it-works).
+`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/docs/guides/webassembly/wasm/#how-it-works).

--- a/examples/webassembly-linear-memory/demo/go/README.md
+++ b/examples/webassembly-linear-memory/demo/go/README.md
@@ -1,3 +1,3 @@
 Compile with TinyGo, by running: `tinygo build -o main.wasm -target wasm ./main.go`
 
-`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/webassembly/webassembly/#how-it-works).
+`wasm_exec.js` can be [copied from your TinyGo root](https://github.com/tinygo-org/tinygo/issues/1070). Which is [explained in the TinyGo Wasm Docs](https://tinygo.org/docs/guides/webassembly/wasm/#how-it-works).


### PR DESCRIPTION
It seems that the strucutre of the tinygo.org site has changed and currently some links on this page are dead (referring to 404 pages). I found working versions of what the links probably pointed to and replaced them where as appropriate.