### PR TITLE
Switch golang pragma from go:export to export

### DIFF
--- a/examples/webassembly-linear-memory/demo/go/main.go
+++ b/examples/webassembly-linear-memory/demo/go/main.go
@@ -17,14 +17,14 @@ func getWasmMemoryBufferPointer() *[BUFFER_SIZE]uint8 {
 
 // Function to store the passed value at index 0,
 // in our buffer 
-//go:export storeValueInWasmMemoryBufferIndexZero
+//export storeValueInWasmMemoryBufferIndexZero
 func storeValueInWasmMemoryBufferIndexZero(value uint8) {
   buffer[0] = value
 }
 
 // Function to read from index 1 of our buffer
 // And return the value at the index
-//go:export readWasmMemoryBufferAndReturnIndexOne
+//export readWasmMemoryBufferAndReturnIndexOne
 func readWasmMemoryBufferAndReturnIndexOne() uint8 {
   return buffer[1]
 }

--- a/examples/webassembly-linear-memory/webassembly-linear-memory.go.en-us.md
+++ b/examples/webassembly-linear-memory/webassembly-linear-memory.go.en-us.md
@@ -34,14 +34,14 @@ func getWasmMemoryBufferPointer() *[BUFFER_SIZE]uint8 {
 
 // Function to store the passed value at index 0,
 // in our buffer
-//go:export storeValueInWasmMemoryBufferIndexZero
+//export storeValueInWasmMemoryBufferIndexZero
 func storeValueInWasmMemoryBufferIndexZero(value uint8) {
   buffer[0] = value
 }
 
 // Function to read from index 1 of our buffer
 // And return the value at the index
-//go:export readWasmMemoryBufferAndReturnIndexOne
+//export readWasmMemoryBufferAndReturnIndexOne
 func readWasmMemoryBufferAndReturnIndexOne() uint8 {
   return buffer[1]
 }


### PR DESCRIPTION
The tinygo website only documents the export pragma, and all the examples switched away to //export
a while ago: https://github.com/tinygo-org/tinygo/pull/1025

This reduces confusion in the guide, which introduces the //export pragma, but never mentions //go:export as an alias.